### PR TITLE
fix: resolve text overlap in mobile Assets/Liabilities sections

### DIFF
--- a/frontend/src/pages/AssetsLiabilities.jsx
+++ b/frontend/src/pages/AssetsLiabilities.jsx
@@ -2290,20 +2290,26 @@ export default function AssetsLiabilities() {
             onClick={() => setAssetsExpanded(!assetsExpanded)}
             transition="border-radius 0.2s"
           >
-            <Box position="relative">
-              <Flex justify="space-between" align="center">
-                <HStack gap={2}>
-                  <Text
-                    fontSize="lg"
-                    transition="transform 0.2s"
-                    transform={assetsExpanded ? "rotate(90deg)" : "rotate(0deg)"}
-                  >
-                    ▶
-                  </Text>
-                  <Text fontSize="xl">📊</Text>
-                  <Heading size={{ base: 'md', md: 'lg' }} color="white">Assets</Heading>
-                  <Text color="whiteAlpha.800" fontSize="sm">({assets.length})</Text>
-                </HStack>
+            <Flex justify="space-between" align="center">
+              <HStack gap={2}>
+                <Text
+                  fontSize="lg"
+                  transition="transform 0.2s"
+                  transform={assetsExpanded ? "rotate(90deg)" : "rotate(0deg)"}
+                >
+                  ▶
+                </Text>
+                <Text fontSize="xl">📊</Text>
+                <Heading size={{ base: 'md', md: 'lg' }} color="white">Assets</Heading>
+              </HStack>
+              <HStack gap={3}>
+                <Text
+                  color="white"
+                  fontSize={{ base: 'md', md: 'lg' }}
+                  fontWeight="bold"
+                >
+                  {formatCurrency(totalAssets)}
+                </Text>
                 <Button
                   bg="white"
                   color="green.700"
@@ -2320,20 +2326,8 @@ export default function AssetsLiabilities() {
                 >
                   +
                 </Button>
-              </Flex>
-              <Text
-                color="white"
-                fontSize={{ base: 'md', md: 'lg' }}
-                fontWeight="bold"
-                position="absolute"
-                left="50%"
-                top="50%"
-                transform="translate(-50%, -50%)"
-                pointerEvents="none"
-              >
-                {formatCurrency(totalAssets)}
-              </Text>
-            </Box>
+              </HStack>
+            </Flex>
           </Box>
           {assetsExpanded && (
             <Box bg={colors.cardBg} borderRadius="0 0 16px 16px" p={4} borderWidth="1px" borderColor={colors.borderColor} borderTop="none">
@@ -2385,20 +2379,26 @@ export default function AssetsLiabilities() {
             onClick={() => setLiabilitiesExpanded(!liabilitiesExpanded)}
             transition="border-radius 0.2s"
           >
-            <Box position="relative">
-              <Flex justify="space-between" align="center">
-                <HStack gap={2}>
-                  <Text
-                    fontSize="lg"
-                    transition="transform 0.2s"
-                    transform={liabilitiesExpanded ? "rotate(90deg)" : "rotate(0deg)"}
-                  >
-                    ▶
-                  </Text>
-                  <Text fontSize="xl">💳</Text>
-                  <Heading size={{ base: 'md', md: 'lg' }} color="white">Liabilities</Heading>
-                  <Text color="whiteAlpha.800" fontSize="sm">({liabilities.length})</Text>
-                </HStack>
+            <Flex justify="space-between" align="center">
+              <HStack gap={2}>
+                <Text
+                  fontSize="lg"
+                  transition="transform 0.2s"
+                  transform={liabilitiesExpanded ? "rotate(90deg)" : "rotate(0deg)"}
+                >
+                  ▶
+                </Text>
+                <Text fontSize="xl">💳</Text>
+                <Heading size={{ base: 'md', md: 'lg' }} color="white">Liabilities</Heading>
+              </HStack>
+              <HStack gap={3}>
+                <Text
+                  color="white"
+                  fontSize={{ base: 'md', md: 'lg' }}
+                  fontWeight="bold"
+                >
+                  {formatCurrency(totalLiabilities)}
+                </Text>
                 <Button
                   bg="white"
                   color="red.700"
@@ -2415,20 +2415,8 @@ export default function AssetsLiabilities() {
                 >
                   +
                 </Button>
-              </Flex>
-              <Text
-                color="white"
-                fontSize={{ base: 'md', md: 'lg' }}
-                fontWeight="bold"
-                position="absolute"
-                left="50%"
-                top="50%"
-                transform="translate(-50%, -50%)"
-                pointerEvents="none"
-              >
-                {formatCurrency(totalLiabilities)}
-              </Text>
-            </Box>
+              </HStack>
+            </Flex>
           </Box>
           {liabilitiesExpanded && (
             <Box bg={colors.cardBg} borderRadius="0 0 16px 16px" p={4} borderWidth="1px" borderColor={colors.borderColor} borderTop="none">


### PR DESCRIPTION
- Remove count numbers from section headers
- Replace absolute positioning with flex layout for dollar amounts
- Place amount next to the + button to prevent overlap on mobile

https://claude.ai/code/session_01JfKn8oeKLakS2TSBp3CQQ3