### PR TITLE
fix: add missing profiles insert to user signup seed function

### DIFF
--- a/backend/database/migrations/004_auto_seed_assets_liabilities.sql
+++ b/backend/database/migrations/004_auto_seed_assets_liabilities.sql
@@ -28,8 +28,12 @@ BEGIN
     (NEW.id, 'Other Debt', '💸');
 
   RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Log error but don't fail the profiles insert / user signup
+  RAISE WARNING 'auto_seed_asset_liability_data failed for user %: % (SQLSTATE: %)', NEW.id, SQLERRM, SQLSTATE;
+  RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 -- Create trigger to auto-seed data when a new user signs up
 DROP TRIGGER IF EXISTS auto_seed_asset_liability_trigger ON profiles;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fix user signup "Database error saving new user" (2026-02-03):**
+  - Added missing `profiles` table INSERT to `seed_new_user_data()` function — the profiles row was removed in an earlier refactor but the table still exists in the schema
+  - This also fixes the `auto_seed_asset_liability_trigger` on `profiles` which was never firing for new users (asset categories and liability types were not being seeded)
+  - Added `EXCEPTION WHEN OTHERS` handler to `auto_seed_asset_liability_data()` to prevent asset/liability seeding failures from blocking signup
+  - Added `SET search_path = public` to all `SECURITY DEFINER` functions for safety
+  - **Action required:** Re-run migration 002 and 004 in Supabase SQL Editor to apply the fix
+
 ### Changed
 - **Smart Budget Suggestions UI Redesign (2026-01-28):**
   - **Collapsible Sections:** Three-level collapse structure


### PR DESCRIPTION
The seed_new_user_data() function was missing the INSERT INTO profiles,
causing "Database error saving new user" on signup. Also added exception
handler to auto_seed_asset_liability_data() and SET search_path = public
to all SECURITY DEFINER functions.

https://claude.ai/code/session_0168ZwBi33KYSmXTm94zX5k6